### PR TITLE
Fix canvas not filling correct grid square.

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,6 +27,9 @@ const drawingCanvasContext = canvas.getContext('2d')
 const guideLinesToggle = document.getElementById('guide-lines-toggle')
 const colorInput = document.getElementById('color-input')
 const clearCanvasBtn = document.getElementById('clear-canvas-btn')
+canvas.width = 600
+canvas.height = 600
+
 
 // Number of cells for canvas length and height
 const cellSideCount = 5


### PR DESCRIPTION
Added canvas.width and canvas.height in order to match the css values.

// i answered you on discord but i didn't see you reply so i just made a pull request to make sure you get the fix
// i also explained why in more detail but basically canvas width and height attributes are not the same as the width and height you give it in css.